### PR TITLE
Near ideal barrel rolling checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Godot Plugin to make the editor do a barrel roll!
 
 ![barrel roll](https://user-images.githubusercontent.com/51323316/151414236-69b01c6c-ec06-480b-becd-653e6eb95ac1.gif)
 
-Hint: Only the world 'barrel' and 'roll' need to be in a comment ;)
+Hint: Only "barrel roll" needs to be in a comment line :D
 
 Download the code as zip, unzip it, add the plugin Directory to the addon directory in your Godot project and activate it in the editor settings. 
 Let everyone see you rollin'!

--- a/addons/DoABarrelRoll/DoABarrelRoll.gd
+++ b/addons/DoABarrelRoll/DoABarrelRoll.gd
@@ -60,6 +60,6 @@ func text_changed(textedit : TextEdit):
 	var line = textedit.cursor_get_line()
 	var line_text = textedit.get_line(line)
 	line_text = line_text.dedent()
-	if line_text.begins_with('#') and "barrel roll" in line_text:
+	if line_text.begins_with('#') and "barrel roll" in line_text.to_lower():
 		do_a_barrel_roll()
 

--- a/addons/DoABarrelRoll/DoABarrelRoll.gd
+++ b/addons/DoABarrelRoll/DoABarrelRoll.gd
@@ -59,6 +59,7 @@ func text_changed(textedit : TextEdit):
 
 	var line = textedit.cursor_get_line()
 	var line_text = textedit.get_line(line)
-	if '#' in line_text and "barrel" in line_text and "roll" in line_text:
+	line_text = line_text.dedent()
+	if line_text.begins_with('#') and "barrel roll" in line_text:
 		do_a_barrel_roll()
 


### PR DESCRIPTION
Only consider comment lines as barrel rollable, make sure "barrel" and "roll" are written one after another, and convert line to lower case before using it to allow Capitalized or ALL CAPS lines to roll too.

Also addresses #1 since lines with code are excluded.